### PR TITLE
added: only 4 latest entered list  income/expense

### DIFF
--- a/src/components/IncomeExpense.js
+++ b/src/components/IncomeExpense.js
@@ -12,14 +12,14 @@ const IncomeExpense = () => {
       <Row style={{ padding: "100px" }}>
         <Col md={6}>
           <Expense expense={expenses} />
-          {listExpense.map((expense, index) => (
+          {listExpense.slice(-4).map((expense, index) => (
             <TransactionList key={index} id={expense.id} money={`-$${expense.money}`} date={expense.currentTime} text={expense.text} />
           ))}
         </Col>
         <Col md={6}>
           <Income income={income} />
-          {listIncome.map((income, index) => (
-            <TransactionList key={index} id={income.id} money={`$${income.money}`} date={income.currentTime} text={income.text} />
+          {listIncome.slice(-4).map((income, index) => (
+            <TransactionList key={index} id={income.id} money={`-$${income.money}`} date={income.currentTime} text={income.text} />
           ))}
         </Col>
       </Row>


### PR DESCRIPTION
we learn how to show 4 or more  list from user latest entered income/expense in home page.

**This is 3 Ways Solutions** 

1. ` {listExpense.slice(-4).map((expense, index) => (
            <TransactionList key={index} id={expense.id} money={`-$${expense.money}`} date={expense.currentTime} text={expense.text} />
          ))}  `

2. `  {listExpense.map((expense, index, arr) => (index > arr.length - 5 ? <TransactionList key={index} id={expense.id} money={`-$${expense.money}`} date={expense.currentTime} text={expense.text} /> : ""))}  `

3.  ` {listIncome
            .filter((_, index, arr) => index > arr.length - 5)
            .map((income, index) => (
              <TransactionList key={index} id={income.id} money={`$${income.money}`} date={income.currentTime} text={income.text} />
            ))}  `